### PR TITLE
Bug Fixes and Test Script Update

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,27 @@
+name: Docker Build and Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Docker image
+        run: |
+          docker build --rm -t test .
+
+      - name: Run Docker container
+        run: |
+          docker run --rm -t -v ${{ github.workspace }}:/root/${GITHUB_WORKSPACE##*/} test bash test.sh

--- a/README.md
+++ b/README.md
@@ -88,3 +88,11 @@ The obfuscation works by compiling the code within each package-related python f
 ## How safe is the obfuscation method?
 
 It is important to note that the obfuscation is not completely secure. It is possible to reverse-engineer your code using the binary files. But even when converting the code back only excerpts of the code will be humanly readable straight away. This method of obfuscation is recommended for code that is not mission-critical but should nevertheless not be deployed as human-readable code.
+
+## Test
+```
+docker build --rm -t test .
+```
+```
+docker run --rm -t -v $(pwd):/root/${PWD##*/} test bash test.sh
+```

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq \
+    tzdata \
+ && rm -rf /var/lib/apt/lists/* # (2) switch to (1)
+# set your timezone
+RUN ln -fs /usr/share/zoneinfo/Asia/Taipei /etc/localtime # (1) switch to (2)
+RUN dpkg-reconfigure -f noninteractive tzdata
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq \
+    wget \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p ~/miniconda3
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
+RUN bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+RUN rm -rf ~/miniconda3/miniconda.sh
+RUN ~/miniconda3/bin/conda init bash
+RUN ~/miniconda3/bin/conda config --set auto_activate_base false
+
+RUN mkdir -p /root/package-obfuscator
+WORKDIR /root/package-obfuscator

--- a/package_obfuscator/file_obfuscator.py
+++ b/package_obfuscator/file_obfuscator.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import py_compile
 import uuid
 
@@ -8,11 +9,19 @@ import marshal
 import os
 
 s = open(os.path.join(os.path.dirname(os.path.realpath(__file__)), '{}', '{}'), 'rb')
-s.seek(16)
+s.seek({})
 exec(marshal.load(s))
 """
 
 
+def _get_header_size():
+    if sys.version_info >= (3, 7):
+        # See: https://peps.python.org/pep-0552/
+        return 16
+    if sys.version_info >= (3, 2):
+        # See: https://www.python.org/dev/peps/pep-3147/
+        return 12
+    return 8
 
 
 def _random_suffix():
@@ -41,7 +50,7 @@ def obfuscate_file(path_to_python, *args, **kwargs):
         renamed_file, cfile=output_pyc_filepath)
 
     # Writing binary parse code to original file
-    new_code = code_template.format(py_cache_folder_name, new_filename_pyc)
+    new_code = code_template.format(py_cache_folder_name, new_filename_pyc, _get_header_size())
     with open(path_to_python, 'w') as f:
         f.write(new_code)
     os.remove(renamed_file)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+for py_version in 3.6 3.7 3.8 3.9 3.10
+do
+echo "Creating python=$py_version environment for test..."
+~/miniconda3/bin/conda create -n test_env python=$py_version -y > /dev/null
+~/miniconda3/bin/conda install -n test_env pytest -y > /dev/null
+~/miniconda3/bin/conda run -n test_env --no-capture-output pytest test --cache-clear
+~/miniconda3/bin/conda env remove --name test_env -y > /dev/null
+find . | grep -E "(/__pycache__$|\.pyc$|\.pyo$)" | xargs rm -rf
+rm -rf test/test_module_output
+rm -rf .pytest_cache
+rm /dev/null
+done

--- a/test.sh
+++ b/test.sh
@@ -11,5 +11,4 @@ echo "Creating python=$py_version environment for test..."
 find . | grep -E "(/__pycache__$|\.pyc$|\.pyo$)" | xargs rm -rf
 rm -rf test/test_module_output
 rm -rf .pytest_cache
-rm /dev/null
 done

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-for py_version in 3.6 3.7 3.8 3.9 3.10
+for py_version in 3.6 3.7 3.8 3.9 3.10 3.11 3.12
 do
 echo "Creating python=$py_version environment for test..."
 ~/miniconda3/bin/conda create -n test_env python=$py_version -y > /dev/null


### PR DESCRIPTION
This pull request addresses a bug related to incorrect byte seeking in obfuscated scripts when using Python 3.6. Additionally, it updates the test scripts to include a Dockerfile for creating virtual environments using Miniconda and a test script (test.sh) to execute pytest across various Python versions (3.6 to 3.10). The README.md file is also updated to provide instructions for running the updated test scripts with Docker Engine.

Changes Made:
1. Bug Fixes:
Fixed the issue where obfuscated scripts were seeking an incorrect byte position in Python 3.6.
The fix ensures that byte seeking now operates correctly.

2. Test Script Updates:
Add `dockerfile` for creating virtual environments using Miniconda.
Add `test.sh` to execute pytest across various Python version (3.6 ~ 3.10).

3. Documentation:
Update `README.md` to provide instructions for running the updated test scripts with Docker Engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added timezone configuration for Asia/Taipei in the Docker environment setup.
    - Enhanced package obfuscation tool to determine header size based on Python version.

- **Documentation**
    - Added testing section with Docker instructions in README.md.

- **Tests**
    - Automated Python environment creation and testing across multiple versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->