### PR TITLE
Shorten obfuscated filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The CLI provides the following options
 | `package_location` (positional) | An absolute or relative path to the package that should be obfuscated                                                                                                                                      |           required |
 | `--output` / `-o`               | An absolute or relative path to a folder in which to place the obfuscated package content. If this argument is not provided the obfuscation will take place in the originally provided `package_location`. | `package_location` |
 | `--force-overwrite` / `-f`      | If the output folder is existent the obfuscator will exit. You can disable this behaviour and achieve a hard overwrite if you add this option                                                              |                    |
-| `--short-filenames` / `-s`      | By adding this option and setting it to `True`, shorter filenames will be generated for the obfuscated files by avoiding the default random uuid in filenames.                                             |                    |
+| `--short-filenames` / `-s`      | By adding this option, shorter filenames will be generated for the obfuscated files by avoiding the default random uuid in filenames.                                                                      |                    |
+| `--py-cache-folder-name` / `-p` | Provide a custom filename for the pycache generated folder.                                                                                                                                                |                    |
 
 ## Python API
 
@@ -47,12 +48,13 @@ The CLI provides the following options
 
 `package_obfuscator.obfuscate(package_dir, [output=..., [force_output_overwrite=False]])`
 
-| Argument                 | Description                                                                                                                                                                   | Required / Optional |
-|:-------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| :------------------ |
-| `package_dir`            | The absolute or relative path to the package directory.                                                                                                                       | Required            |
-| `output`                 | The absolute or relative path to the directory in which to place the obfuscated files. If not provided the obfuscation will take place within the `package_dir`.              | Optional            |
-| `force_output_overwrite` | If the output folder exists when running the code the obfuscator will exit with an exception. If you want to force an overwrite you should provide this argument with `True`. | Optional            |
-| `short_filenames`        | By adding this option and setting it to `True`, shorter filenames will be generated for the obfuscated files by avoiding the default random uuid in filenames.                | Optional            |
+| Argument                     | Description                                                                                                                                                                   | Required / Optional |
+|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| :------------------ |
+| `package_dir`                | The absolute or relative path to the package directory.                                                                                                                       | Required            |
+| `output`                     | The absolute or relative path to the directory in which to place the obfuscated files. If not provided the obfuscation will take place within the `package_dir`.              | Optional            |
+| `force_output_overwrite`     | If the output folder exists when running the code the obfuscator will exit with an exception. If you want to force an overwrite you should provide this argument with `True`. | Optional            |
+| `short_filenames`            | By adding this option, shorter filenames will be generated for the obfuscated files by avoiding the default random uuid in filenames.                                         | Optional            |
+| `py_cache_folder_name`       | Provide a custom filename for the pycache generated folder.                                                                                                                                                                          | Optional            |
 
 ## When to use the `package-obfuscator`
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The CLI provides the following options
 |:--------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| -----------------: |
 | `package_location` (positional) | An absolute or relative path to the package that should be obfuscated                                                                                                                                      |           required |
 | `--output` / `-o`               | An absolute or relative path to a folder in which to place the obfuscated package content. If this argument is not provided the obfuscation will take place in the originally provided `package_location`. | `package_location` |
-| `--force-overwrite` / `-f`      | If the output folder is existent the obfuscator will exit. You can disable this behaviour and achieve an hard overwrite if you add this option                                                             |                    |
+| `--force-overwrite` / `-f`      | If the output folder is existent the obfuscator will exit. You can disable this behaviour and achieve a hard overwrite if you add this option                                                              |                    |
 | `--short-filenames` / `-s`      | By adding this option and setting it to `True`, shorter filenames will be generated for the obfuscated files by avoiding the default random uuid in filenames.                                             |                    |
 
 ## Python API

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ package_obfuscator.obfuscate(package_folder)
 The CLI provides the following options
 
 | Argument                        | Description                                                                                                                                                                                                |            Default |
-| :------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----------------: |
+|:--------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| -----------------: |
 | `package_location` (positional) | An absolute or relative path to the package that should be obfuscated                                                                                                                                      |           required |
 | `--output` / `-o`               | An absolute or relative path to a folder in which to place the obfuscated package content. If this argument is not provided the obfuscation will take place in the originally provided `package_location`. | `package_location` |
 | `--force-overwrite` / `-f`      | If the output folder is existent the obfuscator will exit. You can disable this behaviour and achieve an hard overwrite if you add this option                                                             |                    |
+| `--short-filenames` / `-s`      | By adding this option and setting it to `True`, shorter filenames will be generated for the obfuscated files by avoiding the default random uuid in filenames.                                             |                    |
 
 ## Python API
 
@@ -47,10 +48,11 @@ The CLI provides the following options
 `package_obfuscator.obfuscate(package_dir, [output=..., [force_output_overwrite=False]])`
 
 | Argument                 | Description                                                                                                                                                                   | Required / Optional |
-| :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------ |
+|:-------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| :------------------ |
 | `package_dir`            | The absolute or relative path to the package directory.                                                                                                                       | Required            |
 | `output`                 | The absolute or relative path to the directory in which to place the obfuscated files. If not provided the obfuscation will take place within the `package_dir`.              | Optional            |
 | `force_output_overwrite` | If the output folder exists when running the code the obfuscator will exit with an exception. If you want to force an overwrite you should provide this argument with `True`. | Optional            |
+| `short_filenames`        | By adding this option and setting it to `True`, shorter filenames will be generated for the obfuscated files by avoiding the default random uuid in filenames.                | Optional            |
 
 ## When to use the `package-obfuscator`
 

--- a/package_obfuscator/cli/__init__.py
+++ b/package_obfuscator/cli/__init__.py
@@ -17,6 +17,10 @@ def main():
     parser.add_argument("-s", "--short-filename",
                         action='store_true',
                         help="Enable short names for the files.")
+    parser.add_argument("-p", "--py-cache-folder-name",
+                        type=str,
+                        default=None,
+                        help="Add a custom name for pycache files")
     args = parser.parse_args()
-    obfuscate(args.package_location, output=args.output,
+    obfuscate(args.package_location, output=args.output, py_cache_folder_name=args.py_cache_folder_name,
               force_output_overwrite=args.force_overwrite, short_filenames=args.short_filename)

--- a/package_obfuscator/cli/__init__.py
+++ b/package_obfuscator/cli/__init__.py
@@ -15,8 +15,7 @@ def main():
                         default=None,
                         help="Enable the overwrite of the output folder if the output folder already exists.")
     parser.add_argument("-s", "--short-filename",
-                        type=bool,
-                        default=None,
+                        action='store_true',
                         help="Enable short names for the files.")
     args = parser.parse_args()
     obfuscate(args.package_location, output=args.output,

--- a/package_obfuscator/cli/__init__.py
+++ b/package_obfuscator/cli/__init__.py
@@ -14,6 +14,10 @@ def main():
                         type=bool,
                         default=None,
                         help="Enable the overwrite of the output folder if the output folder already exists.")
+    parser.add_argument("-s", "--short-filename",
+                        type=bool,
+                        default=None,
+                        help="Enable short names for the files.")
     args = parser.parse_args()
     obfuscate(args.package_location, output=args.output,
-              force_output_overwrite=args.force_overwrite)
+              force_output_overwrite=args.force_overwrite, short_filenames=args.short_filename)

--- a/package_obfuscator/file_obfuscator.py
+++ b/package_obfuscator/file_obfuscator.py
@@ -32,8 +32,8 @@ def obfuscate_file(path_to_python, *args, **kwargs):
     base_path = os.path.dirname(path_to_python)
     filename = os.path.basename(path_to_python)
     filename_clean = filename.replace('.py', '')
-    suffix = _random_suffix()
-    interim_python_file_name = f'{filename_clean}_{suffix}.py'
+    suffix = f"_{_random_suffix()}" if not kwargs.get("short_filenames", False) else ""
+    interim_python_file_name = f'{filename_clean}{suffix}.py'
     os.rename(path_to_python, os.path.join(base_path,
               interim_python_file_name))
     renamed_file = os.path.join(

--- a/test/test_obfuscate_folder.py
+++ b/test/test_obfuscate_folder.py
@@ -52,3 +52,25 @@ def test_in_place_obfuscation():
     assert test_module_output.perform() == 2
     hash_1 = _hash_file(os.path.join(output_dir, 'hello_world.py'))
     assert hash_0 != hash_1
+
+
+def test_obfuscate_folder_with_short_filenames():
+    test_module_name = 'test_module'
+    test_module_name_output = 'test_module_output'
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    output_dir = os.path.join(current_dir, test_module_name_output)
+    if os.path.isdir(output_dir) and os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+    assert not os.path.exists(output_dir)
+    package_obfuscator.obfuscate(
+        os.path.join(current_dir, 'test_module'),
+        output=output_dir,
+        force_output_overwrite=True,
+        short_filenames=True
+    )
+    from . import test_module_output
+    assert test_module_output.perform() == 2
+    hash_0 = _hash_file(os.path.join(
+        current_dir, test_module_name, 'hello_world.py'))
+    hash_1 = _hash_file(os.path.join(output_dir, 'hello_world.py'))
+    assert hash_0 != hash_1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced new command-line options `--short-filenames` and `--py-cache-folder-name` for improved control over obfuscation outputs.
  - Updated Python API to reflect new parameters for filename management and cache folder customization.

- **Bug Fixes**
  - Enhanced filename generation logic to conditionally append suffixes based on the `short_filenames` option.

- **Tests**
  - Added a new test to validate the obfuscation behavior with short filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->